### PR TITLE
simplify first markdown cell

### DIFF
--- a/book/Main.ipynb
+++ b/book/Main.ipynb
@@ -7,17 +7,7 @@
    "source": [
     "# Quantitative Analysis of Paleomagnetic Sampling Strategies\n",
     "\n",
-    "_Authors: F Sapienza, L. C. Gallo, Y. Zhang, B. Vaes, M. Domeier, N. L. Swanson-Hysell_\n",
-    "\n",
-    "Preprint available [here](https://scholar.google.com/citations?view_op=view_citation&hl=en&user=yWj-T4oAAAAJ&authuser=1&citation_for_view=yWj-T4oAAAAJ:LkGwnXOMwfcC).\n",
-    "\n",
-    "This [JupytertBook](https://jupyterbook.org/en/stable/intro.html) contains all the requirement notebooks and code to reproduce the analysis for the different sampling procedures in order\n",
-    "to estimate the precision of different strategies at the moment of estimating paleomagnetic poles and secular variation of the magnetic field \n",
-    "based on site observations. \n",
-    "\n",
-    "You can open a cloud JupyterHub version of all the code in this repository and execute it using the following Binder link:\n",
-    "\n",
-    "[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PolarWandering/PaleoSampling/HEAD)\n"
+    "_Authors: F Sapienza, L. C. Gallo, Y. Zhang, B. Vaes, M. Domeier, N. L. Swanson-Hysell_"
    ]
   },
   {


### PR DESCRIPTION
There is repititive text within Main.ipynb between the first markdown cell and the README. Deleting the text in the first markdown cell eliminates this repitition (and makes it easier to maintain when we update the paper link, etc.)